### PR TITLE
In .bashrc, create a docker alias to map 'docker' to 'sudo docker'

### DIFF
--- a/custom-script.sh
+++ b/custom-script.sh
@@ -26,9 +26,12 @@ sudo add-apt-repository -y ppa:webupd8team/java
 # Prep for installing the Atom text editor
 sudo add-apt-repository -y ppa:webupd8team/atom
 
-# Now actually do all the installs
+# Make sure everything is up to date, including system updates.
 sudo apt-get update -y
 sudo apt-get upgrade -y
+#sudo apt-get dist-upgrade -y
+
+# Now actually do all the installs
 sudo apt-get install -y -q oracle-java8-installer
 sudo apt-get install -y -q oracle-java8-set-default
 sudo apt-get install -y -q docker-ce
@@ -36,16 +39,8 @@ sudo apt-get install -y -q google-chrome-stable
 sudo apt-get install -y -q atom
 sudo apt-get install -y -q git
 
-# Manage users
-# sudo groupadd docker
-# sudo usermod -aG docker ubuntu
-# sudo usermod -aG vagrant docker
-
-# Start services
-#sudo systemctl enable docker
-
 # Remove LibreOffice apps
-###sudo apt-get remove -y --purge libreoffice*
+sudo apt-get remove -y --purge libreoffice*
 
 sudo apt-get clean -y
 sudo apt-get autoremove -y

--- a/tpl/vagrantfile-ubuntu17101-desktop.tpl
+++ b/tpl/vagrantfile-ubuntu17101-desktop.tpl
@@ -20,9 +20,14 @@ Vagrant.configure("2") do |config|
 
     config.vm.provision "file", source: "./resources/devstation-config-ui-nonce", destination: "/home/vagrant/devstation-config-ui-nonce"
 
-    config.vm.provision "shell", inline: "sudo mv /home/vagrant/devstation-config-ui-nonce /usr/local/bin/devstation-config-ui-nonce"
-    config.vm.provision "shell", inline: "sudo chmod +x /usr/local/bin/devstation-config-ui-nonce"
-    config.vm.provision "shell", inline: "echo \"[ -f /usr/local/bin/devstation-config-ui-nonce ] && devstation-config-ui-nonce\" >> /home/vagrant/.profile"
+    $script = <<-SCRIPT
+    echo "alias docker=\\\"sudo /usr/bin/docker\\\"" >> /home/vagrant/.bashrc
+    sudo mv /home/vagrant/devstation-config-ui-nonce /usr/local/bin/devstation-config-ui-nonce
+    sudo chmod +x /usr/local/bin/devstation-config-ui-nonce
+    echo \"[ -f /usr/local/bin/devstation-config-ui-nonce ] && devstation-config-ui-nonce\" >> /home/vagrant/.profile
+    SCRIPT
+
+    config.vm.provision "shell", inline: $script
 
     ["vmware_fusion", "vmware_workstation"].each do |provider|
       config.vm.provider provider do |v, override|


### PR DESCRIPTION
This is a recommended approach to avoiding having to use "sudo" before every single docker command. It avoids the risk of granting excessive privilege that comes with adding the vagrant user to the docker group, it maintains logging & auditing via sudo, and it doesn't allow the user to do anything they can't already do just by typing "sudo" before docker commands manually.